### PR TITLE
Fix broken link for CI course

### DIFF
--- a/responses/00_Setup-CI.md
+++ b/responses/00_Setup-CI.md
@@ -32,4 +32,4 @@ Automated events take place throughout this process. These events can range from
 
 But, this is **NOT** a course on CI. We will not being going into detail on what CI means, or how to use CI with GitHub Actions.
 
-Wait! There's good news 👍! If you need a CI refresher you can take the [Using GitHub Actions for CI Learning Lab course](https://lab.github.com/githubtraining/using-github-actions-for-ci)  to get up to speed.
+Wait! There's good news 👍! If you need a CI refresher you can take the [Using GitHub Actions for CI Learning Lab course](https://lab.github.com/githubtraining/github-actions:-continuous-integration) to get up to speed.


### PR DESCRIPTION
A broken link as [reported on Halp](https://halp.githubapp.com/inboxes/learning-lab/discussions/fa20aca833d411ea89f7af548bd751c9?page=1). This PR should fix it.

@githubtraining/trainers can someone 👍 this please? 