### PR TITLE
Update 01.1_Docker-Workflow.md

### DIFF
--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -29,7 +29,7 @@ We are going to edit the current workflow file in our repository by adding addin
         name: webpack artifacts
         path: public
     - name: Build, Tag, Push
-      uses: mattdavis0351/actions/docker-gpr@v1
+      uses: mattdavis0351/actions/docker-gpr@v1.3.0
       with:
         repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         image-name: tic-tac-toe
@@ -103,7 +103,7 @@ jobs:
         name: webpack artifacts
         path: public
     - name: Build, Tag, Push
-      uses: mattdavis0351/actions/docker-gpr@v1
+      uses: mattdavis0351/actions/docker-gpr@v1.3.0
       with:
         repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         image-name: tic-tac-toe


### PR DESCRIPTION
### Why:
This pull request addresses half of #11 

### What has changed:
the `mattdavis0351/actions/docker-gpr` action has been update to throw an error in the event that the package name has been used in a different repository.  

**Overview of the actual error:**
> blob upload invalid: Package "tic-tac-toe" is already associated with another repository.

**Output from the updated action**
> blob upload invalid: Package "tic-tac-toe" is already associated with another repository.
> ##[error]Review the logs above, most likely you are using a package name associated with a different repository.  Rename your Image to fix.

The status of the action is also set to Failed if this error is thrown.

### What has not changed:

The action has not been updated to check if the user has enough free space to store their image with GitHub Packages.  This may be implemented in a future update to the action itself, but may also be easier to handle at the Learning Lab level by providing some sort of feedback based on the stdout of the check_run.  

### We should think this through as a team!
This is a longer term issue for us as we develop content moving forward.  We need to figure out how we can address these things without relying on the creator/maintainer of the actions used to update them so that Learning Labs behave as expected.  

This could be a use case for having out own Learning Lab GitHub Actions repo, or it may be getting new Learning Lab Actions added to the bot so that it can better utilize the output of a given action.

It may also include content creators providing that error checking at the workflow level when developing courses around the GitHub Actions platform.

