### PR TITLE
Change Node.js versions

### DIFF
--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-lastest, windows-2016]
-        node-version: [8.x, 10.x]
+        node-version: [10, 12]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Remove Node 8.x from matrix build.  Support of this version of node ended in December of 2019 and is causing this course to break.  Using versions fo Node that are supported and all the course to complete as expected.