### PR TITLE
Actions is not in beta anymore

### DIFF
--- a/responses/00_Setup-CI.md
+++ b/responses/00_Setup-CI.md
@@ -4,7 +4,7 @@ Welcome to the Learning Lab course "Using GitHub Actions for CD". What is **CD**
 
 Before you get started, it's important that you are comfortable with a few skills. We recommend going through the [Introduction to GitHub Learning Lab course](https://lab.github.com/githubtraining/introduction-to-github/) and the [Hello, GitHub Actions! Learning Lab course](https://lab.github.com/github/hello-github-actions!) before beginning this one. 
 
-You'll also need to [sign up for GitHub Actions](https://github.com/features/actions/signup/). 
+You'll also need to have GitHub Actions enabled for this repository. For more inforation, please check [GitHub Actions](https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions).
 
 Other experience with workflow automation will help, but are not necessary to complete this course.
 


### PR DESCRIPTION
Removing the line recommended to sign up to GitHub Actions and replacing it by more info around Actions and making sure that Actions is enabled.