### PR TITLE
change to official Docker action

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,10 +15,10 @@ before:
 
 steps:
   # step 1
-  - title:  Move the workflow file
+  - title: Move the workflow file
     description: Place the CI workflow file in the proper directory.
     event: pull_request.synchronize
-    link: '{{ repoUrl }}/pull/1'
+    link: "{{ repoUrl }}/pull/1"
     actions:
       - type: getTree
         action_id: tree
@@ -137,7 +137,6 @@ steps:
       #       with: 01.5_Check-Suite-Fail.md
       #       issue: Add a Dockerfile
 
-      
       - type: createIssue
         title: Consuming The Newly Created Docker Image
         body: 02.0_Pull-Run-Image.md
@@ -152,7 +151,7 @@ steps:
         with: 01.6_Success.md
         issue: Add a Dockerfile
         data:
-          nextUrl: '%actions.nextUrl.data.html_url%'
+          nextUrl: "%actions.nextUrl.data.html_url%"
 
       - type: mergePullRequest
         pullRequest: Add a Dockerfile
@@ -203,6 +202,5 @@ steps:
   #       with: 01.5_Check-Suite-Fail.md
   #       issue: Add a Dockerfile
 
-tags: [
-  "GitHub Actions", "GitHub Packages", "Deployment", "Workflows", "Docker"
-]
+tags: ["GitHub Actions", "GitHub Packages", "Deployment", "Workflows", "Docker"]
+# I have to be here... bugs are everywhere... run!

--- a/config.yml
+++ b/config.yml
@@ -203,4 +203,3 @@ steps:
   #       issue: Add a Dockerfile
 
 tags: ["GitHub Actions", "GitHub Packages", "Deployment", "Workflows", "Docker"]
-# I have to be here... bugs are everywhere... run!

--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -10,7 +10,7 @@ We are going to edit the current workflow file in our repository by adding addin
 2. Rename `ci-workflow.yml` to `cd-workflow.yml`:
 3. On line 1, change the name from `Node CI` to `Docker CD`
    `yaml name: Docker CD`
-4. Add the following job to your workflow file (**Be sure to replace `<github-username>` with your own!**):
+4. Add the following job to your workflow file:
 
 ```yaml
   Build-and-Push-Docker-Image:
@@ -32,8 +32,7 @@ We are going to edit the current workflow file in our repository by adding addin
         username: {% raw %}${{github.actor}}{% endraw %}
         password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}
         registry: docker.pkg.github.com
-        # TODO: Replace <github-username> with your username!
-        repository: <github-username>/github-actions-for-packages/tic-tac-toe
+        repository: {{ user.login }}/github-actions-for-packages/tic-tac-toe
         tag_with_sha: true
 ```
 
@@ -107,8 +106,7 @@ jobs:
         username: {% raw %}${{github.actor}}{% endraw %}
         password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}
         registry: docker.pkg.github.com
-        # TODO: Replace <github-username> with your username!
-        repository: <github-username>/github-actions-for-packages/tic-tac-toe
+        repository: {{ user.login }}/github-actions-for-packages/tic-tac-toe
         tag_with_sha: true
 ```
 

--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -9,9 +9,7 @@ We are going to edit the current workflow file in our repository by adding addin
 1. [Edit the current workflow file in our repository]({{ repoUrl }}/blob/docker-workflow/.github/workflows/ci-workflow.yml)
 2. Rename `ci-workflow.yml` to `cd-workflow.yml`:
 3. On line 1, change the name from `Node CI` to `Docker CD`
-        ```yaml
-        name: Docker CD
-        ```
+   `yaml name: Docker CD`
 4. Add the following job to your workflow file:
 
 ```yaml
@@ -44,9 +42,6 @@ name: Docker CD
 
 on:
   push:
-  # branches-ignore:
-  #   - "ci-workflow"
-  #   - "docker-workflow"
     paths:
     - "**Dockerfile**"
 
@@ -70,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-lastest, windows-2016]
-        node-version: [10, 12]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -102,10 +97,15 @@ jobs:
       with:
         name: webpack artifacts
         path: public
-    - name: Build, Tag, Push
-      uses: mattdavis0351/actions/docker-gpr@v1.3.0
+    - name: Build container image
+      uses: docker/build-push-action@v1
       with:
-        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        image-name: tic-tac-toe
+        username: {% raw %}${{github.actor}}{% endraw %}
+        password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}
+        registry: docker.pkg.github.com
+        # TODO: Replace <github-username> with your username!
+        repository: <github-username>/github-actions-for-packages/tic-tac-toe
+        tag_with_sha: true
 ```
+
 </details>

--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -10,7 +10,7 @@ We are going to edit the current workflow file in our repository by adding addin
 2. Rename `ci-workflow.yml` to `cd-workflow.yml`:
 3. On line 1, change the name from `Node CI` to `Docker CD`
    `yaml name: Docker CD`
-4. Add the following job to your workflow file:
+4. Add the following job to your workflow file (**Be sure to replace `<github-username>` with your own!**):
 
 ```yaml
   Build-and-Push-Docker-Image:
@@ -26,11 +26,15 @@ We are going to edit the current workflow file in our repository by adding addin
       with:
         name: webpack artifacts
         path: public
-    - name: Build, Tag, Push
-      uses: mattdavis0351/actions/docker-gpr@v1.3.0
+    - name: Build container image
+      uses: docker/build-push-action@v1
       with:
-        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        image-name: tic-tac-toe
+        username: {% raw %}${{github.actor}}{% endraw %}
+        password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}
+        registry: docker.pkg.github.com
+        # TODO: Replace <github-username> with your username!
+        repository: <github-username>/github-actions-for-packages/tic-tac-toe
+        tag_with_sha: true
 ```
 
 5. Commit the newly edited workflow file to your repository


### PR DESCRIPTION
This pull request moves away from my custom Docker action to use the official action maintained by Docker.  This also allows us to switch the container registry from Packages to Containers when the time is right in a much easier fashion.