### PR TITLE
Typo correction in 01.1_Docker-Workflow

### DIFF
--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -2,7 +2,7 @@
 
 ## Step 2: Edit the workflow file
 
-We are going to edit the current workflow file in our repository by adding adding a job that turns our `Dockerfile` into a `Docker Image`.
+We are going to edit the current workflow file in our repository by adding a job that turns our `Dockerfile` into a `Docker Image`.
 
 ### :keyboard: Activity: Edit the workflow file and turn the Dockerfile into a Docker Image
 


### PR DESCRIPTION
Removed repeated word 'adding' in [01.1_Docker-Workflow](https://github.com/githubtraining/github-actions-publish-to-github-packages/blob/master/responses/01.1_Docker-Workflow.md#step-2-edit-the-workflow-file)
closes #22 