### PR TITLE
Rename all references from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For more information on the goals of this course, check out the [`course-details
 
 ## Contribute
 
-See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/master/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
+See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/main/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
 
-We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/master/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
+We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/main/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
 
 ## License
 

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ steps:
         branch: ci-workflow
 
       - type: mergeBranch
-        head: master
+        head: main
         base: docker-workflow
 
       - type: createPullRequest
@@ -48,7 +48,7 @@ steps:
         head: docker-workflow
         action_id: dockerworkflowpr
         data:
-          workflowUrl: "%payload.repository.html_url%/edit/master/.github/workflows/ci-workflow.yml"
+          workflowUrl: "%payload.repository.html_url%/edit/main/.github/workflows/ci-workflow.yml"
         # workflowUrl sill not accessible in response below
         # respond also breaks if a use a title vs number
       - type: respond
@@ -86,7 +86,7 @@ steps:
         branch: docker-workflow
 
       - type: mergeBranch
-        head: master
+        head: main
         base: add-dockerfile
 
       - type: createPullRequest

--- a/responses/00_Setup-CI.md
+++ b/responses/00_Setup-CI.md
@@ -14,7 +14,7 @@ First, take a moment to examine the image below. It shows the relationship betwe
 
 ![](https://i.imgur.com/xZCkjmU.png)
 
-**Continuous integration** (CI) is a practice where developers  integrate code into a shared branch several times per day.  The shared branch is sometimes referred to as **trunk**, but on Git, it's named **master**. To integrate code, developers **commit** on other Git branches, **push** their changes, and **merge** to master through **pull requests**. 
+**Continuous integration** (CI) is a practice where developers  integrate code into a shared branch several times per day.  The shared branch is sometimes referred to as **trunk**, but on Git, it's named **main**. To integrate code, developers **commit** on other Git branches, **push** their changes, and **merge** to main through **pull requests**. 
 
 Automated events take place throughout this process. These events can range from running tests or deployments to cross-linking to relevant threads. Here's an example that we will use:
 

--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -22,7 +22,7 @@ We are going to edit the current workflow file in our repository by adding a job
     - name: Checkout
       uses: actions/checkout@v1
     - name: Download built artifact
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@main
       with:
         name: webpack artifacts
         path: public
@@ -57,7 +57,7 @@ jobs:
       run: |
         npm install
         npm run build
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@main
       with:
         name: webpack artifacts
         path: public/
@@ -76,7 +76,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: {% raw %}${{ matrix.node-version }}{% endraw %}
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@main
       with:
         name: webpack artifacts
         path: public
@@ -96,7 +96,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Download built artifact
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@main
       with:
         name: webpack artifacts
         path: public

--- a/responses/01.6_Success.md
+++ b/responses/01.6_Success.md
@@ -6,7 +6,7 @@ You now have a Docker image stored in the GitHub Packages.
 
 ![screenshot of repository navigation highlighting the "1 package" button](https://i.imgur.com/HWwlmtn.png)
 
-**You may need to switch to the `master` branch to see your package count increase.**
+**You may need to switch to the `main` branch to see your package count increase.**
 
 ![screenshot of the packages built as seen at the top of the `code` tab](https://i.imgur.com/e9zrFGf.png)
 


### PR DESCRIPTION
This includes references to actions, but after checking the repos, they have all shifted to main as well