### PR TITLE
Update actions version number to v2

### DIFF
--- a/responses/01.1_Docker-Workflow.md
+++ b/responses/01.1_Docker-Workflow.md
@@ -20,14 +20,14 @@ We are going to edit the current workflow file in our repository by adding a job
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Download built artifact
       uses: actions/download-artifact@main
       with:
         name: webpack artifacts
         path: public
     - name: Build container image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: {% raw %}${{github.actor}}{% endraw %}
         password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}


### PR DESCRIPTION
See githubtraining/github-actions-publish-to-github-packages-template#1. Version number should be updated on this step as well.